### PR TITLE
separated size li element from the one its cloned after

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "popup",
   "type": "module",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "name": "GitHub Repo Size",
   "author": "mouiylus@gmail.com",
   "description": "Show size summaries of GitHub repos",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "web_accessible_resources": [
     {
       "resources": ["script.js"],

--- a/src/scripts/internal/dom-manipulation.ts
+++ b/src/scripts/internal/dom-manipulation.ts
@@ -152,6 +152,15 @@ function setTotalSize(repoInfo: GitHubTree) {
 
   span.innerText = formatBytes(totalSize);
 
+  const isSelected = totalSizeButton.classList.contains('selected');
+
+  // Update the style of .UnderlineNav-item.selected:after based on isSelected
+  if (isSelected) {
+    totalSizeButton.style.setProperty(
+      '--underlineNav-borderColor-active',
+      'transparent'
+    );
+  }
   // unique class to identify the new <li> element
   const newLiClass = 'sizeLi';
 

--- a/src/scripts/internal/dom-manipulation.ts
+++ b/src/scripts/internal/dom-manipulation.ts
@@ -116,6 +116,7 @@ function insertToHome(anchor: HTMLAnchorElement, span: HTMLSpanElement) {
  *
  * @param repoInfo - The repo info
  */
+
 function setTotalSize(repoInfo: GitHubTree) {
   let navButtons = getNavButtons();
   if (!navButtons) {
@@ -123,16 +124,20 @@ function setTotalSize(repoInfo: GitHubTree) {
   }
 
   let totalSizeButton = getTotalSizeButton();
+
+  // Check if total size button already exists
   if (!totalSizeButton) {
     totalSizeButton = createTotalSizeButton(navButtons);
+
+    // If creating the button fails, exit the function
     if (!totalSizeButton) {
       return;
     }
   }
 
-  navButtons.appendChild(totalSizeButton);
-  if (!totalSizeButton) {
-    return;
+  const existingCounterSpan = totalSizeButton.querySelector('span.Counter');
+  if (existingCounterSpan) {
+    existingCounterSpan.remove();
   }
 
   const span = getTotalSizeSpan(totalSizeButton);
@@ -146,6 +151,23 @@ function setTotalSize(repoInfo: GitHubTree) {
   });
 
   span.innerText = formatBytes(totalSize);
+
+  // unique class to identify the new <li> element
+  const newLiClass = 'sizeLi';
+
+  const existingLiElement = document.querySelector(
+    `.js-repo-nav li.${newLiClass}`
+  );
+
+  if (!existingLiElement) {
+    const newLiElement = document.createElement('li');
+    newLiElement.classList.add('d-flex', newLiClass);
+    newLiElement.setAttribute('data-view-component', 'true');
+    newLiElement.appendChild(totalSizeButton);
+
+    // Append the new <li> element after the last <li class="d-flex"> within .js-repo-nav
+    navButtons.parentNode?.appendChild(newLiElement);
+  }
 }
 
 /**
@@ -175,9 +197,9 @@ export async function updateDOM() {
   );
   if (!repoInfo || !repoInfo.tree) {
     const warnMessage = `
-    Could not get repo info, aborting...\n 
-    Click the extension button to see remaining requests.\n 
-    If you see 0 remaining requests, you have exceeded the rate limit.\n 
+    Could not get repo info, aborting...\n
+    Click the extension button to see remaining requests.\n
+    If you see 0 remaining requests, you have exceeded the rate limit.\n
     Use OAuth or a personal access token to increase the rate limit.
     `;
     console.warn(warnMessage);

--- a/src/scripts/internal/dom-manipulation.ts
+++ b/src/scripts/internal/dom-manipulation.ts
@@ -1,7 +1,7 @@
 import {
   createSizeLabel,
   createSizeSpan,
-  createTotalSizeButton,
+  createTotalSizeElement,
   formatBytes,
   getAnchors,
   getNavButtons,
@@ -127,7 +127,7 @@ function setTotalSize(repoInfo: GitHubTree) {
 
   // Check if total size button already exists
   if (!totalSizeButton) {
-    totalSizeButton = createTotalSizeButton(navButtons);
+    totalSizeButton = createTotalSizeElement();
 
     // If creating the button fails, exit the function
     if (!totalSizeButton) {
@@ -152,31 +152,7 @@ function setTotalSize(repoInfo: GitHubTree) {
 
   span.innerText = formatBytes(totalSize);
 
-  const isSelected = totalSizeButton.classList.contains('selected');
-
-  // Update the style of .UnderlineNav-item.selected:after based on isSelected
-  if (isSelected) {
-    totalSizeButton.style.setProperty(
-      '--underlineNav-borderColor-active',
-      'transparent'
-    );
-  }
-  // unique class to identify the new <li> element
-  const newLiClass = 'sizeLi';
-
-  const existingLiElement = document.querySelector(
-    `.js-repo-nav li.${newLiClass}`
-  );
-
-  if (!existingLiElement) {
-    const newLiElement = document.createElement('li');
-    newLiElement.classList.add('d-flex', newLiClass);
-    newLiElement.setAttribute('data-view-component', 'true');
-    newLiElement.appendChild(totalSizeButton);
-
-    // Append the new <li> element after the last <li class="d-flex"> within .js-repo-nav
-    navButtons.parentNode?.appendChild(newLiElement);
-  }
+  navButtons.appendChild(totalSizeButton);
 }
 
 /**

--- a/src/scripts/internal/element-factory.ts
+++ b/src/scripts/internal/element-factory.ts
@@ -20,42 +20,29 @@ export function createSizeLabel() {
 }
 
 /**
- * Create an element to display the total size of the files in the repository.
- *
- * @param navButtons - The navigation buttons element
+ * Create a total size element. The element is shown at the end of the navigation bar.
+ * It displays the total size of the repository.
+ * 
  * @returns The total size element
  * @example
  * ```ts
- * createTotalSizeButton(navButtons);
- * // <a class="UnderlineNav-item grs-total-size..."...>
+ * createTotalSizeElement();
+ * // <li style="align-items: center" class="grs-total-size d-inline-flex">
+ * //   <svg>database-icon</svg>
  * //   <span>...</span>
- * // </a>
+ * // </li>
  * ```
  */
-export function createTotalSizeButton(navButtons: ChildNode) {
-  const totalSizeButton = navButtons?.lastChild?.cloneNode(true);
-  if (!(totalSizeButton instanceof HTMLElement)) {
-    return;
-  }
-  totalSizeButton.classList.add('grs-total-size');
-  const navTotalSizeAnchor = totalSizeButton.closest('a');
-  if (!(navTotalSizeAnchor instanceof HTMLElement)) {
-    return;
-  }
-  if (navTotalSizeAnchor.getAttribute('href')) {
-    navTotalSizeAnchor.attributes.removeNamedItem('href');
-  }
-  const svg = navTotalSizeAnchor.firstElementChild;
-  if (!svg) {
-    return;
-  }
-  navTotalSizeAnchor.removeChild(svg);
-  const span = navTotalSizeAnchor.querySelector('span') as
-    | HTMLSpanElement
-    | undefined;
-  if (!(span instanceof HTMLSpanElement)) {
-    return;
-  }
+export function createTotalSizeElement() {
+  const totalSizeButton = document.createElement('li');
+  // unique identifier and GitHub's li style class
+  totalSizeButton.classList.add('grs-total-size', 'd-inline-flex');
+  // align the svg icon with the text
+  totalSizeButton.style.setProperty('align-items', 'center');
+  // create the span element that will contain the total size and append it to the button
+  const span = createTotalSizeSpan();
+  totalSizeButton.appendChild(span);
+  // add the 'database' icon
   span.insertAdjacentHTML(
     'beforebegin',
     `
@@ -65,8 +52,14 @@ export function createTotalSizeButton(navButtons: ChildNode) {
     </svg>
     `
   );
-  span.innerText = '...';
   return totalSizeButton;
+}
+
+function createTotalSizeSpan() {
+  const span = document.createElement('span');
+  // add loading dots to be replaced by the total size
+  span.innerText = '...';
+  return span;
 }
 
 /**

--- a/src/scripts/internal/index.ts
+++ b/src/scripts/internal/index.ts
@@ -3,7 +3,7 @@ export { getRepoInfo } from './api';
 export { formatBytes } from './format';
 export { hashClass } from './crypto';
 export {
-  getSettingsListItem as getNavButtons,
+  getNavButtons,
   getAnchors,
   getTotalSizeButton,
   getSizeLabel,
@@ -13,7 +13,7 @@ export {
 } from './selectors';
 export {
   createSizeLabel,
-  createTotalSizeButton,
+  createTotalSizeElement,
   createSizeSpan,
 } from './element-factory';
 export { updateDOM } from './dom-manipulation';

--- a/src/scripts/internal/selectors.ts
+++ b/src/scripts/internal/selectors.ts
@@ -1,24 +1,10 @@
 /**
- * Get the settings list item from the navigation bar.
- *
- * @returns The settings list item
- * @example
- * ```ts
- * getSettingsListItem();
-// <li data-view-component="true" class="d-inline-flex">
-//   <a id="settings-tab" href="/owner/repo/settings" ...>
-//     <svg ...>
-//       <path ...></path>
-//     </svg>
-//     <span ...>Settings</span>
-//     <span ...></span>
-//   </a>
-// </li>
-* ```
-*/
-export function getSettingsListItem() {
-  return document.querySelector('.js-repo-nav')?.firstElementChild
-    ?.lastElementChild;
+ * Gets the nav button list.
+ * 
+ * @returns element containing the nav buttons
+ */
+export function getNavButtons() {
+  return document.querySelector('.js-repo-nav > ul') as HTMLUListElement | null;
 }
 
 /**


### PR DESCRIPTION
- separated the size element (totalSizeButton) from the previous button by wrapping it in a new li element and giving it a unique class sizeLi to better identify it
- removed the counter span if it exists

![separated-li](https://github.com/AminoffZ/github-repo-size/assets/124379229/0bc069b3-88d9-426a-8bc7-bdc20771a7fb)
But for some reason the previous element click still affects the size element and gets it underlined
![separated-but-underlined](https://github.com/AminoffZ/github-repo-size/assets/124379229/49b73438-5349-4b22-af6b-5aa960a07bc2)
