### PR TITLE
Improve DOM Updates

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-We take your privacy seriously. To better protect your privacy we provide this privacy policy notice explaining the way your personal information is collected and used. 
+We take your privacy seriously. To better protect your privacy we provide this privacy policy notice explaining the way your personal information is collected and used.
 
 ## Links to Third Party Websites
 

--- a/src/scripts/background.ts
+++ b/src/scripts/background.ts
@@ -18,7 +18,7 @@ function setupNavigationHandler() {
     if (url.hostname !== 'github.com') {
       return;
     }
-    // I wish i remembered why i did this
+    // Only send the message every other time to avoid sending the message twice
     redirects[url.href] = (redirects[url.href] || 0) + 1;
     if ((redirects[url.href] + 1) % 2 == 0) {
       return;

--- a/src/scripts/internal/dom-manipulation.ts
+++ b/src/scripts/internal/dom-manipulation.ts
@@ -236,7 +236,7 @@ export async function updateDOM() {
 
   setTotalSize(repoInfo);
 
-  updates.map(({ anchor, span, index }) => {
+  updates.forEach(({ anchor, span, index }) => {
     // for some reason the rows have two td's with name of each file
     if (index % 2 === 1) {
       return insertToFileExplorer(anchor, span);


### PR DESCRIPTION
For some reason, with slow internet things break. Tables are modified and sizes are displayed briefly before being overridden by something else leaving only the column label. To recreate try throttling to <200kb download in dev tools. 

This PR aims to make the communication between the background script and the content script better resulting in more reliable DOM updates.