### PR TITLE
fix submodule size early return

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-We take your privacy seriously. To better protect your privacy we provide this privacy policy notice explaining the way your personal information is collected and used. 
+We take your privacy seriously. To better protect your privacy we provide this privacy policy notice explaining the way your personal information is collected and used.
 
 ## Links to Third Party Websites
 

--- a/src/scripts/internal/dom-manipulation.ts
+++ b/src/scripts/internal/dom-manipulation.ts
@@ -1,6 +1,7 @@
 import {
   createSizeLabel,
   createSizeSpan,
+  createEmptySizeSpan,
   createTotalSizeElement,
   formatBytes,
   getFileAnchors,
@@ -214,13 +215,15 @@ export async function updateDOM() {
     }
 
     const anchorPathObject = getPathObject(anchorPath);
+    let size: number;
+    let span: HTMLSpanElement | undefined;
     if (!repoInfo.tree.some((file) => file.path === anchorPathObject.path)) {
       console.warn('Could not find file in repo info.');
-      return;
+      span = createEmptySizeSpan(anchorPath);
+    } else {
+      size = getSize(anchorPathObject, repoInfo.tree);
+      span = createSizeSpan(anchorPath, size);
     }
-
-    const size = getSize(anchorPathObject, repoInfo.tree);
-    const span = createSizeSpan(anchorPath, size);
 
     if (!span) {
       console.warn('Could not create size span.');

--- a/src/scripts/internal/element-factory.ts
+++ b/src/scripts/internal/element-factory.ts
@@ -103,7 +103,6 @@ export function createSizeSpan(anchorPath: string, size: number) {
  * // <span class="grs grs-...">...</span>
  * ```
  */
-
 export function createEmptySizeSpan(anchorPath: string) {
   const span = document.createElement('span');
   const spanClass = hashClass(anchorPath);

--- a/src/scripts/internal/element-factory.ts
+++ b/src/scripts/internal/element-factory.ts
@@ -91,3 +91,29 @@ export function createSizeSpan(anchorPath: string, size: number) {
   span.innerText = sizeString;
   return span;
 }
+
+/**
+ * Create an empty size span element.
+ *
+ * @param anchorPath - The path of the anchor element used as reference
+ * @returns The empty size span element
+ * @example
+ * ```ts
+ * createEmptySizeSpan(anchorPath);
+ * // <span class="grs grs-...">...</span>
+ * ```
+ */
+
+export function createEmptySizeSpan(anchorPath: string) {
+  const span = document.createElement('span');
+  const spanClass = hashClass(anchorPath);
+  span.classList.add('grs', spanClass);
+
+  if (document.querySelector(`span.${spanClass}`)) {
+    console.warn(`Duplicate span class: ${spanClass}`);
+    return;
+  }
+
+  span.innerText = '...';
+  return span;
+}


### PR DESCRIPTION
This PR closes #26. It places a placeholder for submodules.

<img width="937" alt="image" src="https://github.com/AminoffZ/github-repo-size/assets/56060664/936c0917-dfa4-4bd8-9a03-00fbf9a2baf8">
