### PR TITLE
Fixed: entire repository size not shown on nav

### DIFF
--- a/src/scripts/internal/selectors.ts
+++ b/src/scripts/internal/selectors.ts
@@ -4,7 +4,7 @@
  * @returns element containing the nav buttons
  */
 export function getNavButtons() {
-  return document.querySelector('.js-repo-nav > ul') as HTMLUListElement | null;
+  return document.querySelector('nav[aria-label="Repository"] > ul') as HTMLUListElement | null;
 }
 
 /**


### PR DESCRIPTION
### After

<img width="302" height="53" alt="image" src="https://github.com/user-attachments/assets/db5d405d-bda1-4246-97ad-427c88beee95" />


### Before

<img width="341" height="61" alt="image" src="https://github.com/user-attachments/assets/28860583-a40f-4978-9e28-014efbb31302" />

```javascript
console.log(document.querySelector('.js-repo-nav > ul')); // null
```

### Diff

```diff
export function getNavButtons() {
-  return document.querySelector('.js-repo-nav > ul') as HTMLUListElement | null;
+  return document.querySelector('nav[aria-label="Repository"] > ul') as HTMLUListElement | null;
}
```