### PR TITLE
Fix/243 truncated repo tree fallback

### DIFF
--- a/src/scripts/internal/api.ts
+++ b/src/scripts/internal/api.ts
@@ -152,3 +152,36 @@ export async function getRepoInfo(
   });
   return response;
 }
+
+/**
+ * Fallback to fetch the non-recursive contents of a specific directory
+ * when the repository is too large and the main tree API truncates.
+ *
+ * @example
+ * ```ts
+ * getFallbackDirectoryInfo('owner/repo', 'main', 'src');
+ * // [ { name: 'index.ts', path: 'src/index.ts', ... }, ... ]
+ * ```
+ */
+export async function getFallbackDirectoryInfo(
+  repo: string,
+  branch: string,
+  path: string
+) {
+  const headers = await createHeaders();
+  const safePath = path ? `/${path}` : '';
+  const request = new Request(
+    `https://api.github.com/repos/${repo}/contents${safePath}?ref=${branch}`,
+    { headers }
+  );
+
+  const response = await fetch(request).catch((err) => {
+    console.error(err);
+    return undefined;
+  });
+
+  if (response && response.ok) {
+    return await response.json();
+  }
+  return undefined;
+}

--- a/src/scripts/internal/dom-manipulation.ts
+++ b/src/scripts/internal/dom-manipulation.ts
@@ -15,6 +15,7 @@ import {
   getThead,
   getTotalSizeButton,
   getTotalSizeSpan,
+  getFallbackDirectoryInfo
 } from '.';
 import type { GRSUpdate, GitHubTree } from './types';
 
@@ -162,7 +163,7 @@ export async function updateDOM() {
   }
 
   const type = pathObject.type;
-  let branch = pathObject.branch;
+  let branch = pathObject.branch || 'main';
   if (type !== 'tree' && type !== 'blob') {
     branch = 'main';
   }
@@ -181,6 +182,38 @@ export async function updateDOM() {
     console.warn(warnMessage);
     return false;
   }
+
+  // Handle GitHub API truncation (repos with >100k files)
+  if (repoInfo.truncated) {
+    console.warn(
+      'Repository tree truncated by GitHub. Fetching fallback directory data...'
+    );
+
+    const fallbackData = await getFallbackDirectoryInfo(
+      pathObject.owner + '/' + pathObject.repo,
+      branch,
+      pathObject.path || ''
+    );
+
+    if (fallbackData && Array.isArray(fallbackData)) {
+      const existingPaths = new Set(repoInfo.tree.map((f) => f.path));
+
+      fallbackData.forEach((item) => {
+        if (!existingPaths.has(item.path)) {
+          repoInfo.tree.push({
+            path: item.path,
+            mode: '',
+            type: item.type === 'dir' ? 'tree' : 'blob',
+            sha: item.sha,
+            size: item.size ?? 0,
+            url: item.url,
+          });
+          existingPaths.add(item.path);
+        }
+      });
+    }
+  }
+
 
   const updates: GRSUpdate = [];
 

--- a/src/scripts/internal/dom-manipulation.ts
+++ b/src/scripts/internal/dom-manipulation.ts
@@ -15,7 +15,7 @@ import {
   getThead,
   getTotalSizeButton,
   getTotalSizeSpan,
-  getFallbackDirectoryInfo
+  getFallbackDirectoryInfo,
 } from '.';
 import type { GRSUpdate, GitHubTree } from './types';
 
@@ -213,7 +213,6 @@ export async function updateDOM() {
       });
     }
   }
-
 
   const updates: GRSUpdate = [];
 


### PR DESCRIPTION
### Fix: Handle GitHub API tree truncation (100k+ files)

This PR fixes an issue where repository sizes are not displayed (or show `"..."`) for very large repositories.

#### Root cause

The extension relies on the GitHub API endpoint:

```
/repos/:owner/:repo/git/trees/:sha?recursive=1
```

However, GitHub enforces a hard limit of **100,000 files per response**. When this limit is exceeded:

* The response is truncated (`truncated: true`)
* Large portions of the repository tree are missing
* Certain directories (depending on alphabetical order) are never returned

Check the official api for more info:

* [REST API endpoints for Git trees](https://docs.github.com/en/rest/git/trees?apiVersion=2026-03-10#get-a-tree)
* [REST API endpoints for repository contents](https://docs.github.com/en/rest/repos/contents?apiVersion=2026-03-10&versionId=free-pro-team%40latest&category=git&subcategory=trees#get-repository-content)

As a result, the extension fails to find files and outputs `"..."`.

This can be reproduced with:

* [https://github.com/McTavishLab/AvesData/tree/cf49a8c5379d6aab19ab24738c0e968e723d9416/Tree_versions/Aves_1.5/Clements2023](https://github.com/McTavishLab/AvesData/tree/cf49a8c5379d6aab19ab24738c0e968e723d9416/Tree_versions/Aves_1.5/Clements2023)

---

#### Solution

When a truncated tree is detected, this PR introduces a **fallback mechanism**:

* Detect `repoInfo.truncated === true`
* Fetch the currently viewed directory using:

  ```
  /repos/:owner/:repo/contents/:path
  ```
* Inject the returned items into the existing tree

This ensures that visible files in the current directory always have valid size data.

---

#### Limitation (Important)

* Folder sizes may appear as `0 B` in truncated repositories

This is expected, since calculating folder sizes would require recursive fetching, which would:

* Significantly increase API usage
* Potentially freeze the extension on very large repositories

---

#### Changes

* Added `getFallbackDirectoryInfo()` in `api.ts`
* Integrated fallback logic in `updateDOM()` in `dom-manipulation.ts`

---

Closes #243

Before:

![before image](https://github.com/user-attachments/assets/b30f4f8c-e4d6-47fb-939b-1053337e02f3)

After:

![after image](https://github.com/user-attachments/assets/c1a95ffe-ef00-4c00-9c4e-9fa304e3c992)