### PR TITLE
Fix decode URL-encoded paths to correctly match GitHub API tree

### DIFF
--- a/src/scripts/internal/get-path-object.ts
+++ b/src/scripts/internal/get-path-object.ts
@@ -22,12 +22,16 @@ export const getPathObject = (path?: string) => {
   const pathObject = {};
   try {
     const paths = path.split('/');
+    const rawPath = paths.slice(5)?.join('/');
     Object.assign(pathObject, {
       owner: paths.at(1),
       repo: paths.at(2),
       type: paths.at(3),
       branch: paths.at(4),
-      path: paths.slice(5)?.join('/'),
+      // Decode the URI component so foreign characters and spaces match the API
+      // GitHub encodes paths in URLs per RFC 3986, while the Git Trees API returns decoded file paths. This mismatch requires decoding URL paths before comparison.
+      // https://docs.github.com/en/rest/git/trees?apiVersion=2026-03-10#get-a-tree
+      path: rawPath ? decodeURIComponent(rawPath) : undefined,
     });
   } catch (e) {
     console.error(e);


### PR DESCRIPTION
### Fix: Handle URL-encoded paths (non-ASCII characters & spaces)

This PR fixes an issue where file and folder sizes are not displayed for paths containing non-ASCII characters (e.g. Chinese, accented letters) or spaces.

#### Root cause

GitHub encodes paths in URLs. For example:

```
考研目录/0-模板
```

becomes:

```
%E8%80%83%E7%A0%94%E7%9B%AE%E5%BD%95/0-%E6%A8%A1%E6%9D%BF
```

In `get-path-object.ts`, the path was extracted directly from the URL without decoding:

```ts
path: paths.slice(5)?.join('/');
```

However, the GitHub API returns paths in decoded form.

This caused comparisons like:

```ts
file.path === anchorPathObject.path;
```

to fail, resulting in `"..."` being displayed instead of actual sizes.

This can be reproduced with:

* [uestc-course/assets at main • Xovee/uestc-course](https://github.com/Xovee/uestc-course/tree/950970f91115c33fa9db538371a0e1854e474f05/assets)

---

#### Solution

Normalize paths by decoding them before use:

```ts
const rawPath = paths.slice(5)?.join('/');

path: rawPath ? decodeURIComponent(rawPath) : undefined,
```

This ensures consistency between:

- URL-derived paths (encoded)
- API responses (decoded)

---

Before:

![before image](https://github.com/user-attachments/assets/6e830828-1ed4-4d3e-afb7-73fd7fb6b52c)

After:

![after image](https://github.com/user-attachments/assets/11dc5b13-34cb-4c27-b328-6e2895a7bf4b)