### PR TITLE
Feat/9 submodule size support

### DIFF
--- a/src/scripts/internal/api.ts
+++ b/src/scripts/internal/api.ts
@@ -152,3 +152,32 @@ export async function getRepoInfo(
   });
   return response;
 }
+
+/**
+ * Fetch the total working-tree size of an external repository.
+ * Used for calculating Git submodule sizes.
+ *
+ * @param owner - The repository owner
+ * @param repo - The repository name
+ * @returns The total size in bytes
+ *
+ * @example
+ * ```ts
+ * getExternalRepoSize('AminoffZ', 'github-repo-size');
+ * // 204800
+ * ```
+ */
+export async function getExternalRepoSize(
+  owner: string,
+  repo: string
+): Promise<number> {
+  const repoInfo = await getRepoInfo(`${owner}/${repo}`);
+
+  if (!repoInfo || !repoInfo.tree) {
+    return 0;
+  }
+
+  return repoInfo.tree.reduce((totalSize, item) => {
+    return totalSize + (item.size ?? 0);
+  }, 0);
+}

--- a/src/scripts/internal/dom-manipulation.ts
+++ b/src/scripts/internal/dom-manipulation.ts
@@ -15,7 +15,7 @@ import {
   getThead,
   getTotalSizeButton,
   getTotalSizeSpan,
-  getExternalRepoSize
+  getExternalRepoSize,
 } from '.';
 import type { GRSUpdate, GitHubTree } from './types';
 
@@ -203,10 +203,8 @@ export async function updateDOM() {
     if (
       anchorPathObject.owner &&
       anchorPathObject.repo &&
-      (
-        anchorPathObject.owner !== pathObject.owner ||
-        anchorPathObject.repo !== pathObject.repo
-      )
+      (anchorPathObject.owner !== pathObject.owner ||
+        anchorPathObject.repo !== pathObject.repo)
     ) {
       const cacheKey = `${anchorPathObject.owner}/${anchorPathObject.repo}`;
 
@@ -234,7 +232,9 @@ export async function updateDOM() {
     }
 
     // Resume existing logic for standard files/folders
-    else if (!repoInfo.tree.some((file) => file.path === anchorPathObject.path)) {
+    else if (
+      !repoInfo.tree.some((file) => file.path === anchorPathObject.path)
+    ) {
       console.warn('Could not find file in repo info.');
       span = createEmptySizeSpan(anchorPath);
     } else {

--- a/src/scripts/internal/dom-manipulation.ts
+++ b/src/scripts/internal/dom-manipulation.ts
@@ -15,6 +15,7 @@ import {
   getThead,
   getTotalSizeButton,
   getTotalSizeSpan,
+  getExternalRepoSize
 } from '.';
 import type { GRSUpdate, GitHubTree } from './types';
 
@@ -184,6 +185,8 @@ export async function updateDOM() {
 
   const updates: GRSUpdate = [];
 
+  const submoduleSizeCache: Record<string, Promise<number>> = {};
+
   for (let index = 0; index < anchors.length; index++) {
     const anchor = anchors[index];
     const anchorPath = anchor.getAttribute('href');
@@ -195,7 +198,43 @@ export async function updateDOM() {
     const anchorPathObject = getPathObject(anchorPath);
     let size: number;
     let span: HTMLSpanElement | undefined;
-    if (!repoInfo.tree.some((file) => file.path === anchorPathObject.path)) {
+
+    // If the anchor links to a different owner/repo, it is a submodule
+    if (
+      anchorPathObject.owner &&
+      anchorPathObject.repo &&
+      (
+        anchorPathObject.owner !== pathObject.owner ||
+        anchorPathObject.repo !== pathObject.repo
+      )
+    ) {
+      const cacheKey = `${anchorPathObject.owner}/${anchorPathObject.repo}`;
+
+      span = createEmptySizeSpan(anchorPath);
+
+      if (span) {
+        span.innerText = 'Loading...';
+      }
+
+      // Start the API fetch in the background
+      if (!submoduleSizeCache[cacheKey]) {
+        submoduleSizeCache[cacheKey] = getExternalRepoSize(
+          anchorPathObject.owner,
+          anchorPathObject.repo
+        );
+      }
+
+      // Lazy load: Update the span text as soon as the promise resolves
+      // (Because 'span' is passed by reference, this updates the UI automatically)
+      submoduleSizeCache[cacheKey].then((resolvedSize) => {
+        if (span) {
+          span.innerText = formatBytes(resolvedSize);
+        }
+      });
+    }
+
+    // Resume existing logic for standard files/folders
+    else if (!repoInfo.tree.some((file) => file.path === anchorPathObject.path)) {
       console.warn('Could not find file in repo info.');
       span = createEmptySizeSpan(anchorPath);
     } else {


### PR DESCRIPTION
This PR adds support for displaying Git submodule sizes directly in the parent repository view.

Previously, submodules would always display `...` because their paths point to a different repository and fail the normal tree lookup logic.

### What changed

* Detect submodule links by checking whether the linked `owner/repo` differs from the current repository.
* Fetch the submodule repository tree and calculate the size using the same logic already used by the extension for normal repositories.
* Lazy load submodule sizes so the rest of the file list renders immediately without waiting for external requests.
* Cache in-flight requests to avoid duplicate API calls caused by GitHub rendering separate mobile/desktop anchors.

Submodules now initially render as `Loading...` and update automatically once the request completes.

This can be reproduced with:
* [https://github.com/frida/frida/](https://github.com/frida/frida/)
___

### Files changed

* Added `getExternalRepoSize()` in `api.ts`
* Updated the main loop in `dom-manipulation.ts`

___

Closes #9 

Before:

![Before image](https://github.com/user-attachments/assets/76fb9d0e-8ff9-476e-9f3a-51dd408f5b40)

After:

![After image](https://github.com/user-attachments/assets/bcab0f47-feba-403e-bb7e-d6b286e00404)