### PR TITLE
Fix respect requested branch and commit hashes when fetching trees

### DIFF
--- a/src/scripts/internal/api.ts
+++ b/src/scripts/internal/api.ts
@@ -135,20 +135,23 @@ export async function getRepoInfo(
   branch: string = 'main',
   attempts: number = 0
 ): Promise<GitHubTree | undefined> {
-  const branchName = (await getDefaultBranch(repo)) || branch;
-  const request = await createTreeRequest(repo, branchName);
-  const response = await fetch(request).then(async (res) => {
-    if (await hasErrors(res)) {
-      if (attempts < 1) {
-        const defaultBranch = await getDefaultBranch(repo);
+  const request = await createTreeRequest(repo, branch);
+  const res = await fetch(request);
+
+  // If the branch does not exist, retry using the repository default branch
+  if (await hasErrors(res)) {
+    if (attempts < 1) {
+      const defaultBranch = await getDefaultBranch(repo);
+
+      if (defaultBranch && defaultBranch !== branch) {
         return getRepoInfo(repo, defaultBranch, attempts + 1);
       }
     }
-    if (attempts > 0) {
-      await setDefaultBranch(repo, branch);
-    }
-    const data = await res.json();
-    return data as GitHubTree;
-  });
-  return response;
+  }
+
+  if (attempts > 0 && res.ok) {
+    await setDefaultBranch(repo, branch);
+  }
+  const data = await res.json();
+  return data as GitHubTree;
 }


### PR DESCRIPTION
### Fix: Respect requested branches and commit hashes

This PR fixes an issue where the extension ignored commit hashes and always fetched the repository's default branch tree.

#### Root cause

`getRepoInfo()` currently resolves the repository default branch before making the tree request:

```ts id="m7g4vw"
const branchName = (await getDefaultBranch(repo)) || branch;
```

This unintentionally overrides:

* commit hashes
* tags
* non-default branches

passed from the current GitHub URL.

As a result, when browsing historical commits such as:

```id="dt2tef"
/tree/cf49a8c...
```

the extension fetched the tree for:

* `main`
* or `master`

instead of the actual commit tree being viewed.

Because the file structure often differs between historical commits and the current branch, file lookups failed and sizes displayed as `"..."`.

This can be reproduced with:

* [init.lua/after/plugin at 249f3b14cc517202c80c6babd0f9ec548351ec71 • ThePrimeagen/init.lua](https://github.com/ThePrimeagen/init.lua/tree/249f3b14cc517202c80c6babd0f9ec548351ec71/after/plugin)

---

#### Solution

`getRepoInfo()` now:

1. uses the requested branch/commit hash first
2. only falls back to the repository default branch if the initial request fails

This preserves support for repositories using:

* `master`
* custom default branches
* detached commit trees
* tags

while correctly handling historical commit views.

---

#### Behavior After Fix

##### Before

```text id="h3l9gi"
User opens old commit
→ extension fetches current main branch
→ paths mismatch
→ sizes become "..."
```
<img width="1842" height="866" alt="2026-05-07_13-39-03" src="https://github.com/user-attachments/assets/07110cb1-12f7-4bc4-a04e-65fba057685b" />

##### After

```text id="pcovb0"
User opens old commit
→ extension fetches exact commit tree
→ paths match correctly
→ sizes display properly
```
<img width="1842" height="866" alt="2026-05-07_13-33-10" src="https://github.com/user-attachments/assets/ea1cd194-ec38-453e-94fd-73c556bae8f8" />
