### PR TITLE
Fix support absolute GitHub URLs in path parser

### DIFF
--- a/src/scripts/internal/get-path-object.ts
+++ b/src/scripts/internal/get-path-object.ts
@@ -19,15 +19,30 @@ import type { PathObject } from './types';
  */
 export const getPathObject = (path?: string) => {
   path = path ?? window.location.pathname;
+
+  // If GitHub injects an absolute URL (common on forks),
+  // extract just the pathname so our index-based parsing doesn't shift and break.
+  if (path.startsWith('http') || path.startsWith('//')) {
+    try {
+      path = new URL(path, window.location.origin).pathname;
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
   const pathObject = {};
   try {
     const paths = path.split('/');
+    const rawPath = paths.slice(5)?.join('/');
     Object.assign(pathObject, {
       owner: paths.at(1),
       repo: paths.at(2),
       type: paths.at(3),
       branch: paths.at(4),
-      path: paths.slice(5)?.join('/'),
+      // Decode the URI component so foreign characters and spaces match the API
+      // GitHub encodes paths in URLs per RFC 3986, while the Git Trees API returns decoded file paths. This mismatch requires decoding URL paths before comparison.
+      // https://docs.github.com/en/rest/git/trees?apiVersion=2026-03-10#get-a-tree
+      path: rawPath ? decodeURIComponent(rawPath) : undefined,
     });
   } catch (e) {
     console.error(e);


### PR DESCRIPTION
### Fix: Handle absolute GitHub URLs in file links

This PR fixes an issue where file sizes could incorrectly display as `"..."` when browsing certain forks or navigating through GitHub's SPA interface.

#### Root cause

The extension currently assumes GitHub file links are always relative URLs:

```id="6nwx53"
/owner/repo/tree/main/path/to/file
```

However, GitHub sometimes injects absolute URLs into the DOM instead:

```id="pw06vw"
https://github.com/owner/repo/tree/main/path/to/file
```

`get-path-object.ts` parses paths using index-based splitting:

```ts id="52rtvg"
const paths = path.split('/');
const rawPath = paths.slice(5)?.join('/');
```

This works for relative paths:

```text id="3mmbfu"
["", "owner", "repo", "tree", "main", "src"]
```

but fails for absolute URLs:

```text id="0sjyco"
["https:", "", "github.com", "owner", "repo", "tree", "main", "src"]
```

Because the indices shift, the parser extracts invalid paths such as:

```text id="wdwzmo"
tree/main/src
```

instead of:

```text id="gv9gy4"
src
```

This causes repository tree lookups to fail, resulting in `"..."` placeholders.

This can be reproduced with:

* [meson/test cases at main • frida/meson](https://github.com/frida/meson/tree/main/test%20cases)

---

#### Solution

Normalize all incoming URLs before parsing.

If the path is absolute:

* extract only the pathname using `URL.pathname`
* preserve the existing relative-path parsing logic

```ts id="a15v4h"
if (path.startsWith('http') || path.startsWith('//')) {
  path = new URL(path, window.location.origin).pathname;
}
```

This guarantees consistent parsing regardless of how GitHub renders the link.

---

#### ⚠️ Important 

This PR assumes that #246 is already merged or will be, so part of that PR is present on this one, due to both touching the same file.

---

Before:

<img width="1842" height="867" alt="2026-05-07_14-28-43" src="https://github.com/user-attachments/assets/f9547e20-f7c2-477c-93fa-f4bff65a5102" />


After:

<img width="1842" height="867" alt="2026-05-07_14-30-30" src="https://github.com/user-attachments/assets/c186c66e-d4b3-49d9-9f2c-26114f079219" />
